### PR TITLE
Redundant semicolon in a code sample

### DIFF
--- a/manuscript/040_Three_Essential_Tools.md
+++ b/manuscript/040_Three_Essential_Tools.md
@@ -263,7 +263,7 @@ public class FakeOrderDatabase : OrderDatabase
 
   public List<Order> SelectAllOrders()
   {
-    return new List<Order>() { _receivedOrder; };
+    return new List<Order>() { _receivedOrder };
   }
 }
 ```


### PR DESCRIPTION
Redundant semicolon was removed. Without it the sample code will not compile.