### PR TITLE
Three dots were removed

### DIFF
--- a/manuscript/070_Practicing_What_We_Already_Learned.md
+++ b/manuscript/070_Practicing_What_We_Already_Learned.md
@@ -349,7 +349,7 @@ public class Calculator
 }
 ```
 
-**Johnny:** Look, now we can run the Specification and watch that Statement evaluate to false, because it expects "0", but gets "Once upon a time in Africa...".
+**Johnny:** Look, now we can run the Specification and watch that Statement evaluate to false, because it expects "0", but gets "Once upon a time in Africa".
 
 **Benjamin:** Running... Ok, it is false. By the way, do you always use such silly values to make Statements false?
 


### PR DESCRIPTION
To be more accurate we need to remove three dots from the quoted text (quoted text should be the same as the one returned by `Display()` method)