### PR TITLE
A somewhat less direct formulation

### DIFF
--- a/manuscript/110_What_is_the_scope_of_a_Statement_in_TDD.md
+++ b/manuscript/110_What_is_the_scope_of_a_Statement_in_TDD.md
@@ -1,6 +1,6 @@
 # What is the scope of a unit-level Statement in TDD?
 
-In previous chapters, I told you how tests form a kind of excutable Specification consisting of many Statements. If so, then some fundamental questions regarding these Statements need to be raised, e.g.:
+In previous chapters, I described how tests form a kind of excutable Specification consisting of many Statements. If so, then some fundamental questions regarding these Statements need to be raised, e.g.:
 
 1. What goes into a single Statement?
 1. Gow do I know that I need to write another Statement instead of expanding existing one?


### PR DESCRIPTION
Change *I told you* to *I described*.

Note that the somewhat direct style may be present in other location too:

```
> path/to/find.exe . -name "*.md" -exec grep -l told \"{}\" ;
.\manuscript\130_Boundaries.md
.\manuscript\140_Triangulation.md
.\manuscript\170_TellDoNotAsk.md
.\manuscript\200_What_does_it_mean_to_compose_objects.md
.\manuscript\210_How_are_objects_composed.md
.\manuscript\230_Designing_for_composabiity_protocols.md
.\manuscript\240_Refactoring_Object_Composition.md
.\manuscript\257_Value objects_general_topics.md
.\manuscript\260_Object_oriented_primer_summary.md
.\manuscript\270_Mock_Objects.md

```