### PR TITLE
wording change

### DIFF
--- a/manuscript/090_How_to_start.md
+++ b/manuscript/090_How_to_start.md
@@ -354,7 +354,7 @@ public void TODO()
  trialMessages.HoldOnASecondWhileWeImportYourDatabase();
 
  //THEN
- Assert.True(false); //to remember about it
+ Assert.True(false); //so we don't forget this later
 }
 ```
 


### PR DESCRIPTION
line 357
 Assert.True(false);
I think I understand you wrote that assertion so that it would purposely fail to remind you to return to it later. 
If that is correct then I feel that it should be worded "So we don't forget this later"